### PR TITLE
add support for setting operationId in route definitions

### DIFF
--- a/src/Deploy/Transformer/Routes.php
+++ b/src/Deploy/Transformer/Routes.php
@@ -93,6 +93,10 @@ class Routes extends TransformerAbstract
                     $methods[$method]['description'] = $config['description'];
                 }
 
+                if (isset($config['operationId'])) {
+                    $methods[$method]['operationId'] = $config['operationId'];
+                }
+
                 if (isset($config['parameters'])) {
                     $methods[$method]['parameters'] = NameGenerator::getSchemaNameFromSource($config['parameters']);
                 }


### PR DESCRIPTION
Add support for reading operationId from route configuration instead of always autogenerating the name

Closes #9  